### PR TITLE
fix(popup): resolve toggle state persistence issue

### DIFF
--- a/src/entrypoints/popup/App.svelte
+++ b/src/entrypoints/popup/App.svelte
@@ -4,9 +4,10 @@
   import type { ExtensionSettings } from '@/utils/types';
   import { DEFAULT_SETTINGS } from '@/utils/types';
 
-  let settings: ExtensionSettings = DEFAULT_SETTINGS;
+  let settings = $state<ExtensionSettings>(DEFAULT_SETTINGS);
   let unwatch: (() => void) | undefined;
-  let loadError: string | null = null;
+  let loadError = $state<string | null>(null);
+  let isLoading = $state(true);
 
   type ToggleItem<K extends keyof ExtensionSettings> = {
     key: keyof ExtensionSettings[K];
@@ -49,6 +50,8 @@
       console.error('Failed to load settings from storage:', error);
       loadError = 'Failed to load settings. Using default values.';
       settings = DEFAULT_SETTINGS;
+    } finally {
+      isLoading = false;
     }
     
     // Watch for external changes
@@ -102,25 +105,29 @@
     </div>
   {/if}
 
-  {#each toggleConfig as { section, title, items }}
-    <section>
-      <h3>{title}</h3>
-      {#each items as item}
-        {@const itemKey = item.key as keyof ExtensionSettings[typeof section]}
-        <div class="toggle-row">
-          <span class="toggle-label" id="{section}-{item.key}-label">{item.label}</span>
-          <label class="switch" for="{section}-{item.key}">
-            <input 
-              type="checkbox" 
-              id="{section}-{item.key}"
-              checked={getSettingValue(section, itemKey)} 
-              on:change={(e) => handleToggle(section, itemKey, e)}
-              aria-labelledby="{section}-{item.key}-label"
-            >
-            <span class="slider" aria-hidden="true"></span>
-          </label>
-        </div>
-      {/each}
-    </section>
-  {/each}
+  {#if isLoading}
+    <div class="loading-state">Loading settings...</div>
+  {:else}
+    {#each toggleConfig as { section, title, items }}
+      <section>
+        <h3>{title}</h3>
+        {#each items as item}
+          {@const itemKey = item.key as keyof ExtensionSettings[typeof section]}
+          <div class="toggle-row">
+            <span class="toggle-label" id="{section}-{item.key}-label">{item.label}</span>
+            <label class="switch" for="{section}-{item.key}">
+              <input 
+                type="checkbox" 
+                id="{section}-{item.key}"
+                checked={getSettingValue(section, itemKey)} 
+                onchange={(e) => handleToggle(section, itemKey, e)}
+                aria-labelledby="{section}-{item.key}-label"
+              >
+              <span class="slider" aria-hidden="true"></span>
+            </label>
+          </div>
+        {/each}
+      </section>
+    {/each}
+  {/if}
 </main>


### PR DESCRIPTION
Fixes #11 

## Problem
The popup toggle states were not persisting correctly when users closed and reopened the popup. While the underlying storage values were correct, the toggles would reset to the 'on' position.

## Root Cause
- Component was rendering with `DEFAULT_SETTINGS` before async storage load completed
- Missing Svelte 5 `$state()` runes for proper fine-grained reactivity
- No loading state to prevent premature rendering with default values

## Changes
- ✅ Added `$state()` runes for reactive state variables (settings, loadError, isLoading)
- ✅ Implemented loading state to delay toggle rendering until settings are loaded
- ✅ Updated deprecated `on:change` to `onchange` event handler
- ✅ Ensures toggle states correctly reflect persisted values on popup reopen

## Testing
- Toggle settings off in popup
- Close popup
- Reopen popup
- Verify toggles maintain their persisted state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a loading indicator that displays while application settings are being loaded in the popup.

* **Bug Fixes**
  * Improved error handling for settings initialization and storage changes with clearer error state management.

* **UI Improvements**
  * Settings controls now display only after loading completes for a better user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->