### PR TITLE
fix(toc): prevent auto-scroll snap-back when scrolling near top

### DIFF
--- a/src/features/tocGenerator.ts
+++ b/src/features/tocGenerator.ts
@@ -143,6 +143,7 @@ function setupActiveHeadingObserver(
 				// Also skip if the first heading is currently visible (handles fast scrolling edge case)
 				const firstHeadingRect = headings[0].getBoundingClientRect();
 				const firstHeadingVisible =
+					// -100 for a big enough margin that's more forgiving for fast scrolling
 					firstHeadingRect.top > -100 &&
 					firstHeadingRect.top < window.innerHeight;
 


### PR DESCRIPTION
Fixes #44 
## 🐛 Problem

The Table of Contents (ToC) auto-scroll feature had an unwanted snap-back behavior when users scrolled near the top of the page. Specifically:

- When the "hide right sidebar" option was **disabled**, the right sidebar contains other elements above the ToC
- When users scrolled **up past the ToC**, the auto-scroll logic would snap the browser viewport back to the first ToC item
- This made the page feel "sticky" and prevented smooth scrolling near the top

### Root Cause

The issue occurred because  scrolls the **entire browser viewport** to bring an element into view. When there are elements above the ToC in the sidebar, this causes the whole page to jump.

## 💭 Solution Brainstorming

### Approach 1: Scroll only the ToC container (Initial attempt)
- Replace  with manual scrolling of just the ToC list container
- Calculate scroll offsets using  and 
- **Problem**: Complex implementation, still had edge cases

### Approach 2: Skip auto-scroll for first item (Selected)
- Simply don't auto-scroll when the first ToC item is active
- Much simpler and more reliable
- **Problem**: Fast scrolling could cause the highlighter to lag, triggering snap-back before the first item is properly highlighted

### Approach 3: Add viewport visibility check (Final)
- Combine Approach 2 with an additional check
- Skip auto-scroll if the first heading is currently visible in the viewport
- Handles both normal case and fast-scrolling edge case

## ✅ Implemented Solution

Added two conditions to skip auto-scroll:

1. **`isFirstItem`**: Don't auto-scroll when the active heading is the first one (normal case)
2. **`firstHeadingVisible`**: Don't auto-scroll when the first heading is visible in viewport (fast scrolling edge case)

The auto-scroll only triggers when **both** conditions are false:
- The active item is NOT the first item
- AND the first heading is NOT currently visible

### Code Changes

```typescript
// Skip auto-scroll for the first item to prevent snap-back when scrolling near the top
const isFirstItem = activeHeading === headings[0];

// Also skip if the first heading is currently visible (handles fast scrolling edge case)
const firstHeadingRect = headings[0].getBoundingClientRect();
const firstHeadingVisible = firstHeadingRect.top > -100 && firstHeadingRect.top < window.innerHeight;

    activeLink.scrollIntoView({ behavior: "smooth", block: "nearest" });
}
```

## 🎯 Reasoning

1. **Simplicity**: The final solution is simple and easy to understand
2. **Performance**: Minimal overhead (just one `getBoundingClientRect()` call per update)
3. **Reliability**: Handles both normal scrolling and fast scrolling edge cases
4. **User Experience**: Eliminates the jarring snap-back behavior while maintaining the helpful auto-scroll for all other ToC items

## 🧪 Testing

Tested with:
- ✅ Scrolling up/down with "hide right sidebar" disabled
- ✅ Fast scrolling near the top
- ✅ Auto-scroll still works for all non-first ToC items
- ✅ No snap-back when scrolling past the ToC

## 📝 Commits

- `1e245a3` - fix(toc): prevent auto-scroll snap-back for first ToC item
- `78cf4e1` - fix(toc): add viewport check to prevent snap-back during fast scrolling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table of contents navigation by refining auto-scroll behavior. Scrolling now adapts intelligently to prevent snap-back when navigating between headings and avoids unnecessary scrolling when viewing the top of the document, improving responsiveness during rapid page scrolling for a smoother navigation experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->