### PR TITLE
 fix reaction drawer positioning when engagement buttons are moved

### DIFF
--- a/src/entrypoints/devto.css
+++ b/src/entrypoints/devto.css
@@ -14,23 +14,24 @@ html.dt-smooth-scroll-enabled {
 /* --- Global Settings --- */
 
 /* Hide Subforem Switcher */
-body.dt-hide-subforem #main-side-bar > * {
+body.dt-hide-subforem #main-side-bar>* {
   display: none !important;
 }
 
 /* --- Layout Cleaning Classes --- */
 
 /* Hide Left Sidebar - Hide content inside sidebars, not the sidebars themselves */
-body.dt-clean-left #sidebar-wrapper-left > * {
+body.dt-clean-left #sidebar-wrapper-left>* {
   display: none !important;
 }
 
 /* Hide Right Sidebar - Hide original content inside sidebar, not the sidebar itself */
 body.dt-clean-right .crayons-layout__sidebar-right {
-  min-width: 320px; /* Maintain sidebar width to match Dev.to's default */
+  min-width: 320px;
+  /* Maintain sidebar width to match Dev.to's default */
 }
 
-body.dt-clean-right .crayons-layout__sidebar-right > *:not(.dt-toc-container) {
+body.dt-clean-right .crayons-layout__sidebar-right>*:not(.dt-toc-container) {
   display: none !important;
 }
 
@@ -102,12 +103,29 @@ body.dark-theme .dt-toc-link.dt-toc-active {
 }
 
 /* Nesting levels */
-.dt-toc-level-1 { margin-left: 0; }
-.dt-toc-level-2 { margin-left: 0.5rem; }
-.dt-toc-level-3 { margin-left: 1rem; }
-.dt-toc-level-4 { margin-left: 1.5rem; }
-.dt-toc-level-5 { margin-left: 2rem; }
-.dt-toc-level-6 { margin-left: 2.5rem; }
+.dt-toc-level-1 {
+  margin-left: 0;
+}
+
+.dt-toc-level-2 {
+  margin-left: 0.5rem;
+}
+
+.dt-toc-level-3 {
+  margin-left: 1rem;
+}
+
+.dt-toc-level-4 {
+  margin-left: 1.5rem;
+}
+
+.dt-toc-level-5 {
+  margin-left: 2rem;
+}
+
+.dt-toc-level-6 {
+  margin-left: 2.5rem;
+}
 
 /* --- Reading Stats --- */
 .dt-reading-stats {
@@ -178,6 +196,21 @@ body.dark-theme .dt-stat-badge {
 .dt-engagement-moved .crayons-tooltip__content {
   white-space: nowrap !important;
   display: block !important;
+}
+
+/* Fix reaction drawer positioning when moved */
+.dt-engagement-moved .reaction-drawer__outer {
+  position: relative !important;
+}
+
+.dt-engagement-moved .reaction-drawer {
+  position: absolute !important;
+  top: 100% !important;
+  left: 0 !important;
+  right: auto !important;
+  bottom: auto !important;
+  transform: translateY(0.5rem) !important;
+  z-index: 500 !important;
 }
 
 /* Dark mode support for moved engagement buttons */
@@ -253,21 +286,27 @@ body.dark-theme .dt-engagement-moved .crayons-reaction__count {
   0% {
     transform: scale(1);
   }
+
   50% {
     transform: scale(1.05);
   }
+
   100% {
     transform: scale(1);
   }
 }
 
 @keyframes dt-copy-shake {
-  0%, 100% {
+
+  0%,
+  100% {
     transform: translateX(0);
   }
+
   25% {
     transform: translateX(-5px);
   }
+
   75% {
     transform: translateX(5px);
   }


### PR DESCRIPTION
Fixes #35

This PR fixes a visual regression where the reaction drawer (the tooltip showing reaction options like 'Love', 'Unicorn', etc.) was appearing in the wrong location when the "Move Engagement Buttons" feature was enabled.

## Root Cause
The "Move Engagement" feature moves the action buttons into a new container in the DOM. This relocation stripped the buttons of their original positioning context. Specifically:
1. The original container provided a positioning context that the absolute-positioned drawer relied on.
2. The new container (`.dt-engagement-moved`) and the moved elements lacked the necessary `position: relative` styles to anchor the drawer.
3. As a result, the drawer's `position: absolute` resolved relative to the viewport or a distant ancestor, causing it to float over the article image instead of the button.

## Solution
This fix introduces specific CSS overrides in [devto.css](cci:7://file:///home/invictus/coding/browser-extensions/devto-enhanced/src/entrypoints/devto.css:0:0-0:0) that target the engagement buttons only when they are in the "moved" state (`.dt-engagement-moved`):
1. **Restored Context**: Applies `position: relative !important` to `.reaction-drawer__outer`, creating a new local coordinate system for the drawer.
2. **Explicit Positioning**: Forces `position: absolute !important` on the `.reaction-drawer` with precise `top`, `left`, and `transform` values to ensure it renders directly below the "Like" button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the reaction drawer positioning system to maintain proper display alignment when engagement elements are repositioned within the layout.
  * Refined CSS formatting, selector consistency, and spacing for improved code organization.
  * Reorganized animation keyframe structure for better stylesheet clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->